### PR TITLE
Add jq as dependency of helios-solo

### DIFF
--- a/helios-solo.rb
+++ b/helios-solo.rb
@@ -7,6 +7,7 @@ class HeliosSolo < Formula
   version "0.8.245"
 
   depends_on "helios" => "0.8.245"
+  depends_on "jq"
 
   def install
     bin.install 'helios-cleanup'


### PR DESCRIPTION
It's used by `helios-use` to parse the tag list from the Docker registry.