### PR TITLE
helios-solo: Let the user know about helios-use

### DIFF
--- a/helios-solo.rb
+++ b/helios-solo.rb
@@ -19,6 +19,19 @@ class HeliosSolo < Formula
     bin.install 'helios-use'
   end
 
+  def caveats; <<-EOS.undent
+    This formula installs the latest version of the helios-solo tools,
+    but it doesn't upgrade the Helios image. If you have upgraded from
+    an older version of helios-solo, switch to the latest image by
+    running:
+
+        helios-use latest
+
+    You can run `helios-use` to switch to any available Helios version
+    whenever you'd like, even without upgrading helios-solo.
+    EOS
+  end
+
   test do
     system "#{bin}/helios-use"
   end


### PR DESCRIPTION
Let the user know about helios-use when they install, and also point out
that upgrading helios-solo doesn't automatically upgrade the underlying
Helios image.