### PR TITLE
fix depends_on "helios" syntax

### DIFF
--- a/helios-solo.rb
+++ b/helios-solo.rb
@@ -1,22 +1,20 @@
-require "formula"
-
 class HeliosSolo < Formula
   homepage "https://github.com/spotify/helios"
   url "https://github.com/spotify/helios/releases/download/0.8.850/helios-solo.zip"
-  sha256 "8b6c9c360798cbe889371f3b28122b234717621696581c38ecf57e67f90eef54"
   version "0.8.850"
+  sha256 "8b6c9c360798cbe889371f3b28122b234717621696581c38ecf57e67f90eef54"
 
-  depends_on "spotify/public/helios" => "0.8.850"
+  depends_on "spotify/public/helios"
   depends_on "jq"
 
   def install
-    bin.install 'helios-cleanup'
-    bin.install 'helios-down'
-    bin.install 'helios-env'
-    bin.install 'helios-restart'
-    bin.install 'helios-solo'
-    bin.install 'helios-up'
-    bin.install 'helios-use'
+    bin.install "helios-cleanup"
+    bin.install "helios-down"
+    bin.install "helios-env"
+    bin.install "helios-restart"
+    bin.install "helios-solo"
+    bin.install "helios-up"
+    bin.install "helios-use"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
I am not sure if something changed within homebrew recently, but the `brew audit` tool reports that it does not understand the syntax used in `depends_on` to depend on a version:

```
$> brew audit helios-solo
spotify/public/helios-solo:
  * Dependency spotify/public/helios does not define option "0.8.850"
Error: 1 problem in 1 formula
```

I started to investigate this when trying to figure out why `brew install helios-solo` did not actually install helios-solo for me (homebrew seems to stop just before downloading the zip):

```
$ brew install helios-solo
==> Installing helios-solo from spotify/public
==> Installing dependencies for spotify/public/helios-solo: spotify/public/helios
==> Installing spotify/public/helios-solo dependency: spotify/public/helios
==> Downloading https://oss.sonatype.org/service/local/repositories/releases/content/com/spotify/helios-tools/0.8.850/helios-tools-
Already downloaded: /Users/mattbrown/Library/Caches/Homebrew/helios-0.8.850.jar
🍺  /usr/local/Cellar/helios/0.8.850: 3 files, 13.9M, built in 1 second
==> Installing spotify/public/helios-solo
==> Installing dependencies for spotify/public/helios-solo: spotify/public/helios

# where is solo??
$ which helios-solo
$
```

I've also fixed some style issues in the formula:

```
$> brew audit --strict helios-solo
spotify/public/helios-solo:
  * `version` (line 7) should be put before `checksum` (line 6)
  * Formula should have a desc (Description).
  * Dependency spotify/public/helios does not define option "0.8.850"
  * `require "formula"` is now unnecessary
  * C: 13: col 17: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  * C: 14: col 17: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  * C: 15: col 17: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  * C: 16: col 17: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  * C: 17: col 17: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  * C: 18: col 17: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  * C: 19: col 17: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
Error: 11 problems in 1 formula
```