### PR TITLE
Hard code scio-repl classpath

### DIFF
--- a/scio.rb
+++ b/scio.rb
@@ -20,7 +20,7 @@ class Scio < Formula
           fi
       done
 
-      exec java ${java_opts[*]} -jar #{libexec}/"scio-repl-#{version}.jar" ${scio_opts[*]}
+      CLASSPATH=#{libexec}/"scio-repl-#{version}.jar":$CLASSPATH exec java ${java_opts[*]} ${scio_opts[*]} java com.spotify.scio.repl.ScioShell
     EOS
   end
 


### PR DESCRIPTION
Scio as of writing (0.3.x,0.4.x) has mechanism to pick up Kryo
serializers from classpath, by looking through the class names.
If classpath is not specified for java process, CWD is included
thus for sufficiently large CWD looking for classes in CWD can
be an expensive operation. Thus this commit hard codes classpath
of scio-repl to scio repl jar itself. Still appends user defined
CLASSPATH variable.