### PR TITLE
fix homebrew error when installing helios-solo

### DIFF
--- a/helios-solo.rb
+++ b/helios-solo.rb
@@ -17,7 +17,7 @@ class HeliosSolo < Formula
     bin.install "helios-use"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     This formula installs the latest version of the helios-solo tools,
     but it doesn't upgrade the Helios image. If you have upgraded from
     an older version of helios-solo, switch to the latest image by


### PR DESCRIPTION
```
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/spotify/homebrew-public/helios-solo.rb:30:in `caveats'
Please report this to the spotify/public tap!
Or, even better, submit a PR to fix it!
```