### PR TITLE
helios: set SUPPRESS_GCLOUD_CREDS_WARNING environment variable

### DIFF
--- a/helios.rb
+++ b/helios.rb
@@ -9,8 +9,13 @@ class Helios < Formula
   depends_on :java => "1.7+"
 
   def install
-    libexec.install "helios-tools-0.9.230-shaded.jar"
-    bin.write_jar_script libexec/"helios-tools-0.9.230-shaded.jar", "helios", "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none"
+    jarfile = "helios-tools-#{version}-shaded.jar"
+    libexec.install jarfile
+    (bin+"helios").write <<~EOS
+      #!/usr/bin/env bash
+      export SUPPRESS_GCLOUD_CREDS_WARNING=true
+      exec java -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none -jar #{libexec}/#{jarfile} "$@"
+    EOS
   end
 
   test do


### PR DESCRIPTION
Have to stop using [write_jar_script][0] as it does not support passing
in environment variables.

Writing the script inline instead, which I picked up from the scio
formula.

[0]: https://www.rubydoc.info/github/Homebrew/brew/Pathname:write_jar_script