### PR TITLE
replace deprecated `depends_on :java`

### DIFF
--- a/helios.rb
+++ b/helios.rb
@@ -6,7 +6,7 @@ class Helios < Formula
   sha256 "d6461bd3d45ca51bc5b75af479e75c0d060b249dee6a9c92692cf2f5ba97bd0d"
   version "0.9.282"
 
-  depends_on :java => "1.7+"
+  depends_on "openjdk@8"
 
   def install
     jarfile = "helios-tools-#{version}-shaded.jar"


### PR DESCRIPTION
recent versions of Homebrew are generating this warning:

```
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the spotify/public tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/spotify/homebrew-public/helios.rb:9
```