### PR TITLE
Update GCS tools depends_on

### DIFF
--- a/gcs-avro-tools.rb
+++ b/gcs-avro-tools.rb
@@ -9,7 +9,7 @@ class GcsAvroTools < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on "openjdk@11"
 
   def install
     libexec.install "avro-tools-1.10.0.jar"

--- a/gcs-parquet-tools.rb
+++ b/gcs-parquet-tools.rb
@@ -9,7 +9,7 @@ class GcsParquetTools < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on "openjdk@11"
 
   def install
     libexec.install "parquet-tools-1.11.1.jar"

--- a/gcs-proto-tools.rb
+++ b/gcs-proto-tools.rb
@@ -7,7 +7,7 @@ class GcsProtoTools < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on "openjdk@11"
 
   def install
     libexec.install "proto-tools-3.12.4.jar"


### PR DESCRIPTION
`depends_on :java` is deprecated ... tools seem to run fine with 11