### PR TITLE
helios: depend on openjdk formula

### DIFF
--- a/helios.rb
+++ b/helios.rb
@@ -6,7 +6,7 @@ class Helios < Formula
   sha256 "d6461bd3d45ca51bc5b75af479e75c0d060b249dee6a9c92692cf2f5ba97bd0d"
   version "0.9.282"
 
-  depends_on "openjdk@8"
+  depends_on "openjdk"
 
   def install
     jarfile = "helios-tools-#{version}-shaded.jar"


### PR DESCRIPTION
instead of openjdk@8 specifically.
`helios` should be able to run on newer JDK versions.
`openjdk` without a version should be 11 which works.