### PR TITLE
scio: remove deprecated `bottle :unneeded`

### DIFF
--- a/scio.rb
+++ b/scio.rb
@@ -4,8 +4,6 @@ class Scio < Formula
   url "https://github.com/spotify/scio/releases/download/v0.11.1/scio-repl.jar"
   sha256 "67897fa8d7b624cfea45f7749067c22fd4ed1e6d18c418c924136cff1aa012f6"
 
-  bottle :unneeded
-
   def install
     libexec.install "scio-repl.jar"
     (bin+"scio-repl").write <<~EOS


### PR DESCRIPTION
Right now when `brew update`ing I get this warning.

```
brew update
Updated Homebrew from fecacdce4 to 241dd2ce2.
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the spotify/public tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/spotify/homebrew-public/scio.rb:7
```

homebrew deprecated it [here](https://github.com/Homebrew/brew/pull/11239).
There's no replacement, and I don't think it's needed anymore.