### PR TITLE
remove the deprecated use of bottle :unneeded

### DIFF
--- a/gcs-avro-tools.rb
+++ b/gcs-avro-tools.rb
@@ -7,8 +7,6 @@ class GcsAvroTools < Formula
 
   conflicts_with "avro-tools", :because => "provides the same binaries/links."
 
-  bottle :unneeded
-
   def install
     libexec.install "avro-tools-1.10.1.jar"
     bin.write_jar_script libexec/"avro-tools-1.10.1.jar", "avro-tools"

--- a/gcs-magnolify-tools.rb
+++ b/gcs-magnolify-tools.rb
@@ -5,8 +5,6 @@ class GcsMagnolifyTools < Formula
   sha256 "1303da523b684e91437d3392a36fa67901f65fc56d2552ee821f6acccc06091c"
   version "0.2.1"
 
-  bottle :unneeded
-
   def install
     libexec.install "magnolify-tools-0.4.3.jar"
     bin.write_jar_script libexec/"magnolify-tools-0.4.3.jar", "magnolify-tools"

--- a/gcs-parquet-cli.rb
+++ b/gcs-parquet-cli.rb
@@ -5,8 +5,6 @@ class GcsParquetCli < Formula
   sha256 "393a74b908f270a50920f3161b8a968ed3f1179fff1051efc892e46be212c8a8"
   version "0.2.1"
 
-  bottle :unneeded
-
   def install
     libexec.install "parquet-cli-1.11.1.jar"
     bin.write_jar_script libexec/"parquet-cli-1.11.1.jar", "parquet-cli"

--- a/gcs-parquet-tools.rb
+++ b/gcs-parquet-tools.rb
@@ -7,8 +7,6 @@ class GcsParquetTools < Formula
 
   conflicts_with "parquet-tools", :because => "provides the same binaries/links."
 
-  bottle :unneeded
-
   deprecate! date: "2021-03-08", because: "is deprecated upstream, use parquet-cli instead"
 
   def install

--- a/gcs-proto-tools.rb
+++ b/gcs-proto-tools.rb
@@ -5,8 +5,6 @@ class GcsProtoTools < Formula
   sha256 "1eb98fa8899886d3cc706a260f7340c6ac670bdd3097a87dcd5f550995dd3d07"
   version "0.2.1"
 
-  bottle :unneeded
-
   def install
     libexec.install "proto-tools-3.15.5.jar"
     bin.write_jar_script libexec/"proto-tools-3.15.5.jar", "proto-tools"


### PR DESCRIPTION
Removes the bottle :unneeded feature as this use is deprecated.
Currently, when installing these formulae, the following error is shown:

    Warning: Calling bottle :unneeded is deprecated! There is no replacement.
    Please report this issue to the spotify/public tap (not Homebrew/brew or Homebrew/core):
      /usr/local/Homebrew/Library/Taps/spotify/homebrew-public/gcs-avro-tools.rb:10

This is similiar to other changes in this repo, such as #91.

Fixes #94