### PR TITLE
Pin openjdk version to 21

### DIFF
--- a/helios.rb
+++ b/helios.rb
@@ -6,7 +6,7 @@ class Helios < Formula
   sha256 "d6461bd3d45ca51bc5b75af479e75c0d060b249dee6a9c92692cf2f5ba97bd0d"
   version "0.9.282"
 
-  depends_on "openjdk"
+  depends_on "openjdk@21"
 
   def install
     jarfile = "helios-tools-#{version}-shaded.jar"


### PR DESCRIPTION
jdk 23 (the current version of openjdk) isn't compatible with the hadoop tools that gcs-tools relies on.

Trying to use `avro-tools` for example with the default latest `openjdk` results in the following error:
```
Exception in thread "main" java.lang.UnsupportedOperationException: getSubject is supported only if a security manager is allowed
	at java.base/javax.security.auth.Subject.getSubject(Subject.java:347)
	at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:577)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3884)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3874)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3662)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:557)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:365)
	at org.apache.avro.tool.Util.openFromFS(Util.java:88)
	at org.apache.avro.tool.Util.fileOrStdin(Util.java:64)
	at org.apache.avro.tool.DataFileReadTool.run(DataFileReadTool.java:86)
	at org.apache.avro.tool.Main.run(Main.java:67)
	at org.apache.avro.tool.Main.main(Main.java:56)
```